### PR TITLE
Some fixes to settlement window queries

### DIFF
--- a/src/db.js
+++ b/src/db.js
@@ -330,7 +330,11 @@ const historicalParticipantLimitQuery = `
 `;
 
 const settlementWindowInfoQuery = `
-SELECT totals.settlementWindowId, totals.settlementWindowStateId AS settlementWindowStateId, sum(totals.amount) AS amount, GROUP_CONCAT(totals.currencyId),
+SELECT
+  totals.settlementWindowId,
+  totals.settlementWindowStateId AS settlementWindowStateId,
+  SUM(totals.amount) AS amount,
+  GROUP_CONCAT(DISTINCT(totals.currencyId)) as currencyId,
   DATE_FORMAT(MIN(swOpen.createdDate), '%Y-%m-%dT%T.000Z') AS settlementWindowOpen,
   DATE_FORMAT(MIN(swClose.createdDate), '%Y-%m-%dT%T.000Z') AS settlementWindowClose
 FROM  (

--- a/src/handlers/settlement-windows.js
+++ b/src/handlers/settlement-windows.js
@@ -19,15 +19,13 @@ const handler = (router, routesContext) => {
     });
 
     router.get('/settlement-windows/:settlementWindowId', async (ctx, next) => {
-        const currentSettlementWindowId = await routesContext.db.getCurrentSettlementWindowId();
-        const thisSettlementWindowId = parseInt(ctx.params.settlementWindowId);
         const settlementWindow = await routesContext.db.getSettlementWindowInfo(ctx.params.settlementWindowId);
-
-        if (currentSettlementWindowId !== thisSettlementWindowId) {
-            const api = new Model({ endpoint: routesContext.config.centralLedgerEndpoint });
+        try {
+            const api = new Model({ endpoint: routesContext.config.settlementsEndpoint });
             const settlement = await api.getSettlements({ settlementWindowId: ctx.params.settlementWindowId });
             settlementWindow.settlement = (settlement.length === 1 ? settlement[0] : {});
-        } else {
+        } catch(error) {
+            routesContext.log(error);
             settlementWindow.settlement = {};
         }
         ctx.response.body = settlementWindow;


### PR DESCRIPTION
Some of these queries were syntactically incorrect but were accepted and executed with some bad default behaviour by previous versions of MySQL. This was because some of the columns in the select statements were returning multiple values per row, with no grouping or aggregation function specified. In the past, MySQL was accepting these queries and using `ANY_VALUE` as the default aggregation function. This PR better specifies these queries.