### PR TITLE
Leverage an external settlement API 

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -21,6 +21,7 @@ const config = {
         listenPort: process.env.LISTEN_PORT,
     },
     fxpEndpoint: process.env.FXP_ENDPOINT,
+    tmfEndpoint: process.env.TMF_ENDPOINT,
     settlementsEndpoint: process.env.SETTLEMENTS_ENDPOINT,
     centralLedgerEndpoint: process.env.CENTRAL_LEDGER_ENDPOINT,
     settlementManagementEndpoint: process.env.SETTLEMENT_MANAGEMENT_ENDPOINT,

--- a/src/handlers/settlement-window-commit.js
+++ b/src/handlers/settlement-window-commit.js
@@ -15,7 +15,7 @@ const handler = (router, routesContext) => {
                 ctx.params.settlementWindowId,
             );
         } catch (error) {
-            routesContext.log('TMF API Error', util.inspect(error, { depth: 10 }));
+            routesContext.log('Settlement API Error', util.inspect(error, { depth: 10 }));
             ctx.response.body = { msg: 'TMF API Error' };
             ctx.response.status = 502;
 

--- a/src/handlers/settlement-window-commit.js
+++ b/src/handlers/settlement-window-commit.js
@@ -16,7 +16,7 @@ const handler = (router, routesContext) => {
             );
         } catch (error) {
             routesContext.log('Settlement API Error', util.inspect(error, { depth: 10 }));
-            ctx.response.body = { msg: 'TMF API Error' };
+            ctx.response.body = { msg: 'Settlement API Error' };
             ctx.response.status = 502;
 
             await next();

--- a/src/handlers/settlement-window-commit.js
+++ b/src/handlers/settlement-window-commit.js
@@ -1,79 +1,24 @@
-const {
-    admin: { api: { getParticipants } }, settlement: { api: SettlementsModel },
-} = require('@mojaloop/finance-portal-lib');
-const {
-    getSettlementWindows, bigifyPaymentMatrix, segmentParticipants,
-    processPaymentsMatrixAndGetFailedPayments,
-} = require('../lib/handlerHelpers');
+const portalLib = require('@mojaloop/finance-portal-lib');
+const util = require('util');
+
+const { commitSettlementWindow } = portalLib.admin.api;
+const { getSettlementWindows } = require('../lib/handlerHelpers');
 
 const handler = (router, routesContext) => {
     router.put('/settlement-window-commit/:settlementWindowId', async (ctx, next) => {
-        const {
-            settlementId, participants, startDate: fromDateTime, endDate: toDateTime,
-        } = ctx.request.body;
+        const { startDate, endDate } = ctx.request.body;
+        let mostRecentSettlementWindow;
 
-        // Get an exclusive connection for use in this handler. This prevents double-processing.
-        // See https://modusbox.atlassian.net/browse/MOWDEV-2433
-        const conn = await routesContext.db.connection.getConnection();
-        // Fetch unprocessed payments and attempt to process them
-        let failedPayments = [];
         try {
-            routesContext.log('Getting the payment matrix to process the funds for '
-                + `settlementWindowId - ${ctx.params.settlementWindowId}, `
-                + `settlementId - ${settlementId}`);
-            const incomingMatrixResult = await routesContext.Database
-                .getPaymentMatrixForUpdate(conn, settlementId);
-            const unprocessedPaymentsMatrix = incomingMatrixResult
-                ? bigifyPaymentMatrix(JSON.parse(incomingMatrixResult)) : [];
-            routesContext.log(`Got the payment matrix: ${unprocessedPaymentsMatrix}`);
-
-            if (unprocessedPaymentsMatrix.length !== 0) {
-                const dfsps = await getParticipants(routesContext.config.centralLedgerEndpoint,
-                    routesContext.log);
-                failedPayments = await processPaymentsMatrixAndGetFailedPayments(
-                    unprocessedPaymentsMatrix, dfsps, participants,
-                    routesContext.config.centralLedgerEndpoint, routesContext.log,
-                );
-            }
+            await commitSettlementWindow(
+                routesContext.config.settlementsEndpoint,
+                ctx.params.settlementWindowId,
+            );
         } catch (error) {
-            routesContext.log(error);
-            routesContext.log(`Error while processing the payment matrix: ${error.message}`);
-            if (error.code === 'ER_LOCK_WAIT_TIMEOUT') {
-                ctx.response.status = 500;
-                await next();
-                return;
-            }
-        }
+            routesContext.log('TMF API Error', util.inspect(error, { depth: 10 }));
+            ctx.response.body = { msg: 'TMF API Error' };
+            ctx.response.status = 502;
 
-        // Commit the transaction and remove the database lock in every circumstance
-        routesContext.log('Updating the state of payment matrix: settlementId - '
-        + `${settlementId}, state - ${failedPayments}`);
-        await routesContext.Database
-            .updatePaymentMatrixState(conn, settlementId, JSON.stringify(failedPayments));
-        routesContext.log('Successfully updated the state of payment matrix: settlementId - '
-        + `${settlementId}, state - ${failedPayments}`);
-        await conn.release();
-
-        // Terminate and change response status if there are payments that failed to process
-        if (failedPayments.length !== 0) {
-            ctx.response.status = 500;
-            await next();
-            return;
-        }
-
-        // Otherwise, settle the window
-        const api = new SettlementsModel({ endpoint: routesContext.config.settlementsEndpoint });
-        const {
-            payerParticipants, payeeParticipants, allParticipants,
-        } = segmentParticipants(participants);
-        try {
-            await api.putSettlement(settlementId, { participants: payerParticipants });
-            await api.putSettlement(settlementId, { participants: payeeParticipants });
-            await api.putSettlement(settlementId, { participants: allParticipants });
-            ctx.response.status = 200;
-        } catch (error) {
-            routesContext.log(`An error occurred during putSettlement: ${error.message}`);
-            ctx.response.status = 500;
             await next();
             return;
         }
@@ -82,15 +27,18 @@ const handler = (router, routesContext) => {
         try {
             const settlementWindows = await getSettlementWindows(
                 routesContext,
-                fromDateTime,
-                toDateTime,
+                startDate,
+                endDate,
                 ctx.params.settlementWindowId,
             );
-            const mostRecentSettlementWindow = settlementWindows[0];
-            ctx.response.body = mostRecentSettlementWindow || {};
+
+            [mostRecentSettlementWindow] = settlementWindows;
         } catch (error) {
             routesContext.log(`An error occurred during getSettlementWindow: ${error.message}`);
         }
+
+        ctx.response.body = mostRecentSettlementWindow || {};
+        ctx.response.status = 200;
         await next();
     });
 };

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/finance-portal-backend-service",
-  "version": "8.8.8",
+  "version": "9.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -406,9 +406,9 @@
       }
     },
     "@mojaloop/finance-portal-lib": {
-      "version": "0.0.4-snapshot",
-      "resolved": "https://registry.npmjs.org/@mojaloop/finance-portal-lib/-/finance-portal-lib-0.0.4-snapshot.tgz",
-      "integrity": "sha512-mKnwOd8PXxC4QpnAC2XpoXsdDZtMFwBj9QJhgEJBnZpjo1R/LkvIvzTUBcswQXFxD6hCgKI3t0TEeO/06pw8WA==",
+      "version": "0.0.5-snapshot",
+      "resolved": "https://registry.npmjs.org/@mojaloop/finance-portal-lib/-/finance-portal-lib-0.0.5-snapshot.tgz",
+      "integrity": "sha512-T3J1cWAlk4TlmaoMP173VPCbktHGRzD+pd8My/dQaDaupPSWJYRqhvuCVAQo7llburZeaqGgHIqa5WEdWj2/pQ==",
       "requires": {
         "big.js": "5.2.2",
         "node-fetch": "2.3.0",

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/finance-portal-backend-service",
-  "version": "8.8.8",
+  "version": "9.1.0",
   "description": "The backend service to support the finance portal web ui. Essentially a thin wrapper around SQL queries.",
   "license": "Apache-2.0",
   "contributors": [
@@ -16,7 +16,7 @@
   },
   "homepage": "https://github.com/mojaloop/finance-portal-backend-service#readme",
   "dependencies": {
-    "@mojaloop/finance-portal-lib": "0.0.4-snapshot",
+    "@mojaloop/finance-portal-lib": "0.0.5-snapshot",
     "axios": "0.18.1",
     "base64url": "3.0.1",
     "big.js": "5.2.2",

--- a/src/test/handlers/settlement-window-commit.test.js
+++ b/src/test/handlers/settlement-window-commit.test.js
@@ -1,144 +1,68 @@
+const portalLib = require('@mojaloop/finance-portal-lib');
 const request = require('supertest');
+const handlerHelpers = require('../../lib/handlerHelpers');
 const mockData = require('./mock-data');
 const support = require('./_support.js');
 
-const { Database } = support;
-
-jest.genMockFromModule('node-fetch');
-jest.mock('node-fetch', () => jest.fn().mockImplementation(() => Promise.resolve({
-    status: 200, statusText: 'OK', ok: true,
-})));
-
 let server;
 let db;
-const logger = () => {};
 
 beforeEach(async () => {
-    Database.getPaymentMatrixForUpdate = jest.fn()
-        .mockImplementation((conn, settlementId) => {
-            if (settlementId === '1') {
-                return Promise.resolve('[["XOF","1",-25],["XOF","2",-15],["XOF","2",15],["XOF","1","25"]]');
-            }
-            if (settlementId === '2') {
-                return Promise.resolve('[["XOF","1",-25],["XOF","1",-15],["XOF","2","15"],["XOF","3","-15"]]');
-            }
-            if (settlementId === '3') {
-                return Promise.resolve('[["XOF","1",-25],["XOF","1",-15],["XOF","2","15"],["XOF","3","-15"]]');
-            }
-            if (settlementId === '4') {
-                return Promise.resolve('[["XOF","1",-25],["XOF","1",-15],["XOF","2","15"],["XOF","3","-15"]]');
-            }
-            return null;
-        });
-    Database.updatePaymentMatrixState = jest.fn();
-
     db = support.createDb();
-    server = support.createServer(db, logger, Database);
+    server = support.createServer(db);
 });
 
 afterEach(async () => {
     server.close();
 });
 
-jest.mock('@mojaloop/finance-portal-lib', () => ({
-    admin: {
-        api: {
-            getParticipantAccounts: jest.fn()
-                .mockImplementation(() => Promise.resolve(
-                    [
-                        ...mockData.positionAccounts,
-                        ...mockData.settleSettlementWindow.settlementAccounts,
-                    ],
-                )),
-            getParticipants: jest.fn()
-                .mockImplementation(() => Promise.resolve(
-                    [
-                        ...mockData.dfsps,
-                    ],
-                )),
-            participantFundsOutPrepareReserve: jest.fn()
-                .mockImplementation((endpoint, participantName) => {
-                    if (participantName === 'testfsp3' || participantName === 'testfsp4') {
-                        throw new Error('This fsp should fail');
-                    }
-                    return true;
-                }),
-            participantFundsInReserve: jest.fn()
-                .mockImplementation((endpoint, participantName) => {
-                    if (participantName === 'testfsp4') {
-                        throw new Error('This fsp should fail');
-                    }
-                    return true;
-                }),
-        },
-    },
-    settlement: {
-        api: jest.fn(() => ({ // this is required because its a constructor
-            putSettlement: jest.fn().mockImplementation(() => ({
-            })),
-        })),
-    },
-    requests: {
-        HTTPResponseError: jest.fn().mockImplementation(() => ({
-        })),
-    },
-}));
-
 describe('PUT /settlement-window-commit/:settlementWindowId', () => {
-    test('should do funds in/out and settle window and return the settlement window with SETTLED status', async () => {
-        const response = await request(server)
-            .put(`/settlement-window-commit/${mockData.settleSettlementWindow.request[0].settlementWindowId}`)
-            .send(mockData.settleSettlementWindow.request[0].body);
-        expect(response.status).toEqual(200);
-        const expectedWindow = mockData.settlementWindowList
-            .find(a => a.settlementWindowId.toString()
-                === mockData.settleSettlementWindow.request[0].settlementWindowId);
-        expect(response.body).toEqual(expectedWindow);
+    portalLib.admin.api.commitSettlementWindow = jest.fn();
+    handlerHelpers.getSettlementWindows = jest.fn();
+
+    afterEach(() => {
+        portalLib.admin.api.commitSettlementWindow.mockClear();
+        handlerHelpers.getSettlementWindows.mockClear();
     });
 
-    test('should settle window and return the settlement window with SETTLED status, when there are no funds in/out pending', async () => {
-        const response = await request(server)
-            .put(`/settlement-window-commit/${mockData.settleSettlementWindow.request[0].settlementWindowId}`)
-            .send(mockData.settleSettlementWindow.request[0].body);
-        expect(response.status).toEqual(200);
-        const expectedWindow = mockData.settlementWindowList
-            .find(a => a.settlementWindowId.toString()
-                === mockData.settleSettlementWindow.request[0].settlementWindowId);
-        expect(response.body).toEqual(expectedWindow);
-    });
+    describe('Failures:', () => {
+        test('should return status code 502 in case `commitSettlementWindow` fails', async () => {
+            portalLib.admin.api.commitSettlementWindow.mockImplementation(jest.fn(() => { throw new Error('foo'); }));
 
-    test('should return status code 500 if one of the funds out fails', async () => {
-        const response = await request(server)
-            .put(`/settlement-window-commit/${mockData.settleSettlementWindow.request[3].settlementWindowId}`)
-            .send(mockData.settleSettlementWindow.request[3].body);
-        const expectedBody = {};
-        expect(response.status).toEqual(500);
-        expect(response.body).toEqual(expectedBody);
-    });
+            const response = await request(server)
+                .put(`/settlement-window-commit/${mockData.settleSettlementWindow.request[3].settlementWindowId}`)
+                .send(mockData.settleSettlementWindow.request[3].body);
+            expect(response.status).toEqual(502);
+            expect(response.body).toEqual({ msg: 'TMF API Error' });
+        });
 
-    test('should return status code 500 if a row lock is encountered', async () => {
-        Database.getPaymentMatrixForUpdate = jest.fn()
-            .mockImplementation(() => { throw { code: 'ER_LOCK_WAIT_TIMEOUT' }; }); // eslint-disable-line no-throw-literal
-        server = support.createServer(db, logger, Database);
-        const { body } = mockData.settleSettlementWindow.request[3];
-        const response = await request(server)
-            .put(`/settlement-window-commit/${body.settlementWindowId}`)
-            .send(body);
-        expect(Database.getPaymentMatrixForUpdate.mock.calls[0][1]).toEqual(body.settlementId);
-        expect(Database.getPaymentMatrixForUpdate.mock.calls.length).toEqual(1);
-        expect(response.status).toEqual(500);
-        expect(response.body).toEqual({});
-    });
+        test('should return a successful status code in case `getSettlementWindows` fails', async () => {
+            portalLib.admin.api.commitSettlementWindow
+                .mockImplementation(jest.fn(() => Promise.resolve()));
+            handlerHelpers.getSettlementWindows.mockImplementation(jest.fn(() => { throw new Error('foo'); }));
 
-    test('should return status code 500 and only save failed transactions to the db if one fails', async () => {
-        const response = await request(server)
-            .put(`/settlement-window-commit/${mockData.settleSettlementWindow.request[3].settlementWindowId}`)
-            .send(mockData.settleSettlementWindow.request[3].body);
-        const expectedBody = {};
-        const expectedArgs = JSON.stringify([['XOF', '3', '-15']]);
-        expect(Database.updatePaymentMatrixState.mock.calls.length).toBe(1);
-        expect(Database.updatePaymentMatrixState.mock.calls[0][2]).toEqual(expectedArgs);
-        expect(response.status).toEqual(500);
-        expect(response.body).toEqual(expectedBody);
+            const response = await request(server)
+                .put(`/settlement-window-commit/${mockData.settleSettlementWindow.request[3].settlementWindowId}`)
+                .send(mockData.settleSettlementWindow.request[3].body);
+            expect(response.status).toEqual(200);
+            expect(response.body).toEqual({});
+        });
+    });
+    describe('Success:', () => {
+        test('should respond with a valid and latest settlement window in case it succeeds.', async () => {
+            portalLib.admin.api.commitSettlementWindow
+                .mockImplementation(jest.fn(() => Promise.resolve()));
+            handlerHelpers
+                .getSettlementWindows
+                .mockImplementation(
+                    jest.fn(() => Promise.resolve(mockData.settlementWindowList)),
+                );
+
+            const response = await request(server)
+                .put(`/settlement-window-commit/${mockData.settleSettlementWindow.request[3].settlementWindowId}`)
+                .send(mockData.settleSettlementWindow.request[3].body);
+            expect(response.status).toEqual(200);
+            expect(response.body).toEqual(mockData.settlementWindowList[0]);
+        });
     });
 });

--- a/src/test/handlers/settlement-window-commit.test.js
+++ b/src/test/handlers/settlement-window-commit.test.js
@@ -33,7 +33,7 @@ describe('PUT /settlement-window-commit/:settlementWindowId', () => {
                 .put(`/settlement-window-commit/${mockData.settleSettlementWindow.request[3].settlementWindowId}`)
                 .send(mockData.settleSettlementWindow.request[3].body);
             expect(response.status).toEqual(502);
-            expect(response.body).toEqual({ msg: 'TMF API Error' });
+            expect(response.body).toEqual({ msg: 'Settlement API Error' });
         });
 
         test('should return a successful status code in case `getSettlementWindows` fails', async () => {


### PR DESCRIPTION
Leverage an external settlement API for `PUT /settlement-window-commit/:settlementWindowId`
 by removing implementation-specific settlement code and adding a call to an implementation-agnostic settlement API.