### PR TITLE
Pass the `settlementWindowId` as a number to `commitSettlementWindow`

### DIFF
--- a/src/handlers/settlement-window-commit.js
+++ b/src/handlers/settlement-window-commit.js
@@ -12,7 +12,7 @@ const handler = (router, routesContext) => {
         try {
             await commitSettlementWindow(
                 routesContext.config.externalSettlementsEndpoint,
-                ctx.params.settlementWindowId,
+                Number(ctx.params.settlementWindowId),
             );
         } catch (error) {
             routesContext.log('Settlement API Error', util.inspect(error, { depth: 10 }));

--- a/src/handlers/settlement-window-commit.js
+++ b/src/handlers/settlement-window-commit.js
@@ -6,13 +6,13 @@ const { getSettlementWindows } = require('../lib/handlerHelpers');
 
 const handler = (router, routesContext) => {
     router.put('/settlement-window-commit/:settlementWindowId', async (ctx, next) => {
-        const { startDate, endDate } = ctx.request.body;
+        const { settlementId, startDate, endDate } = ctx.request.body;
         let mostRecentSettlementWindow;
 
         try {
             await commitSettlementWindow(
                 routesContext.config.externalSettlementsEndpoint,
-                Number(ctx.params.settlementWindowId),
+                Number(settlementId),
             );
         } catch (error) {
             routesContext.log('Settlement API Error', util.inspect(error, { depth: 10 }));

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/finance-portal-backend-service",
-  "version": "9.1.0",
+  "version": "9.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/finance-portal-backend-service",
-  "version": "9.1.1",
+  "version": "9.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/finance-portal-backend-service",
-  "version": "9.1.0",
+  "version": "9.1.1",
   "description": "The backend service to support the finance portal web ui. Essentially a thin wrapper around SQL queries.",
   "license": "Apache-2.0",
   "contributors": [

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/finance-portal-backend-service",
-  "version": "9.1.1",
+  "version": "9.1.2",
   "description": "The backend service to support the finance portal web ui. Essentially a thin wrapper around SQL queries.",
   "license": "Apache-2.0",
   "contributors": [

--- a/src/test/handlers/settlement-window-commit.test.js
+++ b/src/test/handlers/settlement-window-commit.test.js
@@ -1,5 +1,6 @@
 const portalLib = require('@mojaloop/finance-portal-lib');
 const request = require('supertest');
+const config = require('../../config/config');
 const handlerHelpers = require('../../lib/handlerHelpers');
 const mockData = require('./mock-data');
 const support = require('./_support.js');
@@ -20,7 +21,14 @@ describe('PUT /settlement-window-commit/:settlementWindowId', () => {
     portalLib.admin.api.commitSettlementWindow = jest.fn();
     handlerHelpers.getSettlementWindows = jest.fn();
 
+    const targetSettlementWindowId = mockData.settleSettlementWindow.request[3].settlementWindowId;
+
     afterEach(() => {
+        expect(portalLib.admin.api.commitSettlementWindow.mock.calls[0][0])
+            .toEqual(config.externalSettlementsEndpoint);
+        expect(portalLib.admin.api.commitSettlementWindow.mock.calls[0][1])
+            .toStrictEqual(Number(targetSettlementWindowId));
+
         portalLib.admin.api.commitSettlementWindow.mockClear();
         handlerHelpers.getSettlementWindows.mockClear();
     });
@@ -30,7 +38,7 @@ describe('PUT /settlement-window-commit/:settlementWindowId', () => {
             portalLib.admin.api.commitSettlementWindow.mockImplementation(jest.fn(() => { throw new Error('foo'); }));
 
             const response = await request(server)
-                .put(`/settlement-window-commit/${mockData.settleSettlementWindow.request[3].settlementWindowId}`)
+                .put(`/settlement-window-commit/${targetSettlementWindowId}`)
                 .send(mockData.settleSettlementWindow.request[3].body);
             expect(response.status).toEqual(502);
             expect(response.body).toEqual({ msg: 'Settlement API Error' });
@@ -42,7 +50,7 @@ describe('PUT /settlement-window-commit/:settlementWindowId', () => {
             handlerHelpers.getSettlementWindows.mockImplementation(jest.fn(() => { throw new Error('foo'); }));
 
             const response = await request(server)
-                .put(`/settlement-window-commit/${mockData.settleSettlementWindow.request[3].settlementWindowId}`)
+                .put(`/settlement-window-commit/${targetSettlementWindowId}`)
                 .send(mockData.settleSettlementWindow.request[3].body);
             expect(response.status).toEqual(200);
             expect(response.body).toEqual({});
@@ -59,8 +67,8 @@ describe('PUT /settlement-window-commit/:settlementWindowId', () => {
                 );
 
             const response = await request(server)
-                .put(`/settlement-window-commit/${mockData.settleSettlementWindow.request[3].settlementWindowId}`)
-                .send(mockData.settleSettlementWindow.request[3].body);
+                .put(`/settlement-window-commit/${targetSettlementWindowId}`)
+                .send();
             expect(response.status).toEqual(200);
             expect(response.body).toEqual(mockData.settlementWindowList[0]);
         });

--- a/src/test/handlers/settlement-window-commit.test.js
+++ b/src/test/handlers/settlement-window-commit.test.js
@@ -22,12 +22,13 @@ describe('PUT /settlement-window-commit/:settlementWindowId', () => {
     handlerHelpers.getSettlementWindows = jest.fn();
 
     const targetSettlementWindowId = mockData.settleSettlementWindow.request[3].settlementWindowId;
+    const targetBody = mockData.settleSettlementWindow.request[3].body;
 
     afterEach(() => {
         expect(portalLib.admin.api.commitSettlementWindow.mock.calls[0][0])
             .toEqual(config.externalSettlementsEndpoint);
         expect(portalLib.admin.api.commitSettlementWindow.mock.calls[0][1])
-            .toStrictEqual(Number(targetSettlementWindowId));
+            .toStrictEqual(Number(targetBody.settlementId));
 
         portalLib.admin.api.commitSettlementWindow.mockClear();
         handlerHelpers.getSettlementWindows.mockClear();
@@ -39,7 +40,7 @@ describe('PUT /settlement-window-commit/:settlementWindowId', () => {
 
             const response = await request(server)
                 .put(`/settlement-window-commit/${targetSettlementWindowId}`)
-                .send(mockData.settleSettlementWindow.request[3].body);
+                .send(targetBody);
             expect(response.status).toEqual(502);
             expect(response.body).toEqual({ msg: 'Settlement API Error' });
         });
@@ -51,7 +52,7 @@ describe('PUT /settlement-window-commit/:settlementWindowId', () => {
 
             const response = await request(server)
                 .put(`/settlement-window-commit/${targetSettlementWindowId}`)
-                .send(mockData.settleSettlementWindow.request[3].body);
+                .send(targetBody);
             expect(response.status).toEqual(200);
             expect(response.body).toEqual({});
         });
@@ -68,7 +69,7 @@ describe('PUT /settlement-window-commit/:settlementWindowId', () => {
 
             const response = await request(server)
                 .put(`/settlement-window-commit/${targetSettlementWindowId}`)
-                .send();
+                .send(targetBody);
             expect(response.status).toEqual(200);
             expect(response.body).toEqual(mockData.settlementWindowList[0]);
         });


### PR DESCRIPTION
Pass the `settlementId` to `commitSettlementWindow` instead of `settlementWindowId`;
Ensure that the `settlementId` is passed as a number to `commitSettlementWindow` instead of a string;
Updated unit tests to verify the above changes.