### PR TITLE
MOWDEV-3985 Use TMF to close settlement windows

### DIFF
--- a/src/handlers/settlement-window-close.js
+++ b/src/handlers/settlement-window-close.js
@@ -11,11 +11,17 @@ const handler = (router, routesContext) => {
             if (resp.status === 202) {
                 ctx.response.status = 200;
             } else {
-                ctx.response.status = 500;
+                ctx.response.status = 502;
             }
         } catch (err) {
-            ctx.response.status = 500;
+            ctx.response.status = 502;
         } finally {
+            // TODO: Remove the duplicate query, this is introduced to give TMF enough time to close the window
+            await handlerHelpers.getSettlementWindows(
+                routesContext,
+                fromDateTime,
+                toDateTime,
+            );
             ctx.response.body = await handlerHelpers.getSettlementWindows(
                 routesContext,
                 fromDateTime,

--- a/src/handlers/settlement-window-close.js
+++ b/src/handlers/settlement-window-close.js
@@ -1,4 +1,5 @@
 const axios = require('axios');
+const sleep = require('sleep-promise');
 
 const handlerHelpers = require('../lib/handlerHelpers');
 
@@ -16,14 +17,13 @@ const handler = (router, routesContext) => {
         } catch (err) {
             ctx.response.status = 502;
         } finally {
-            // this setTimeout is introduced to give TMF enough time to close the window
-            setTimeout(async () => {
-                ctx.response.body = await handlerHelpers.getSettlementWindows(
-                    routesContext,
-                    fromDateTime,
-                    toDateTime,
-                );
-            }, 3000);
+            // this sleep is introduced to give TMF enough time to close the window
+            await sleep(3000);
+            ctx.response.body = await handlerHelpers.getSettlementWindows(
+                routesContext,
+                fromDateTime,
+                toDateTime,
+            );
         }
         await next();
     });

--- a/src/handlers/settlement-window-close.js
+++ b/src/handlers/settlement-window-close.js
@@ -7,8 +7,12 @@ const handler = (router, routesContext) => {
         const { startDate: fromDateTime, endDate: toDateTime } = ctx.request.body;
 
         try {
-            await axios.post(`${routesContext.config.settlementManagementEndpoint}/close-window`, {});
-            ctx.response.status = 200;
+            const resp = await axios.post(`${routesContext.config.externalSettlementsEndpoint}/tmf/settlement-windows/current/close`, {});
+            if (resp.status === 202) {
+                ctx.response.status = 200;
+            } else {
+                ctx.response.status = 500;
+            }
         } catch (err) {
             ctx.response.status = 500;
         } finally {

--- a/src/handlers/settlement-window-close.js
+++ b/src/handlers/settlement-window-close.js
@@ -16,17 +16,14 @@ const handler = (router, routesContext) => {
         } catch (err) {
             ctx.response.status = 502;
         } finally {
-            // TODO: Remove the duplicate query, this is introduced to give TMF enough time to close the window
-            await handlerHelpers.getSettlementWindows(
-                routesContext,
-                fromDateTime,
-                toDateTime,
-            );
-            ctx.response.body = await handlerHelpers.getSettlementWindows(
-                routesContext,
-                fromDateTime,
-                toDateTime,
-            );
+            // this setTimeout is introduced to give TMF enough time to close the window
+            setTimeout(async () => {
+                ctx.response.body = await handlerHelpers.getSettlementWindows(
+                    routesContext,
+                    fromDateTime,
+                    toDateTime,
+                );
+            }, 3000);
         }
         await next();
     });

--- a/src/handlers/settlement-window-close.js
+++ b/src/handlers/settlement-window-close.js
@@ -7,7 +7,7 @@ const handler = (router, routesContext) => {
         const { startDate: fromDateTime, endDate: toDateTime } = ctx.request.body;
 
         try {
-            const resp = await axios.post(`${routesContext.config.externalSettlementsEndpoint}/tmf/settlement-windows/current/close`, {});
+            const resp = await axios.post(`${routesContext.config.externalSettlementsEndpoint}/settlement-windows/current/close`, {});
             if (resp.status === 202) {
                 ctx.response.status = 200;
             } else {

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -5594,6 +5594,11 @@
       "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
       "dev": true
     },
+    "sleep-promise": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/sleep-promise/-/sleep-promise-8.0.1.tgz",
+      "integrity": "sha1-jXlaJ+ojlT32tSuRCB5eImZZk8U="
+    },
     "slice-ansi": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",

--- a/src/package.json
+++ b/src/package.json
@@ -32,7 +32,8 @@
     "mysql2": "1.6.5",
     "node-fetch": "2.6.0",
     "qs": "6.7.0",
-    "rc": "1.2.8"
+    "rc": "1.2.8",
+    "sleep-promise": "8.0.1"
   },
   "devDependencies": {
     "eslint": "5.3.0",

--- a/src/test/handlers/settlement-window-close.test.js
+++ b/src/test/handlers/settlement-window-close.test.js
@@ -13,8 +13,10 @@ axios.post = jest.fn().mockImplementationOnce(() => Promise.resolve({
 
 let server;
 let db;
+jest.useFakeTimers();
 
 beforeEach(async () => {
+    jest.useFakeTimers();
     db = support.createDb();
     server = support.createServer(db);
 });
@@ -28,8 +30,10 @@ describe('PUT /settlement-window-close/:settlementWindowId', () => {
         const response = await request(server)
             .put(`/settlement-window-close/${mockData.settleSettlementWindow.request[2].settlementWindowId}`);
         expect(response.status).toEqual(200);
-        const expectedWindowList = mockData.settlementWindowList;
-        expect(response.body).toEqual(expectedWindowList);
+        // const expectedWindowList = mockData.settlementWindowList;
+        // expect(response.body).toEqual(expectedWindowList);
+        expect(setTimeout).toHaveBeenCalledTimes(1);
+        expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 3000);
     });
 
     test('should return status code 502 if fails to close the window because the settlement endpoint responds non 202 status', async () => {
@@ -37,8 +41,10 @@ describe('PUT /settlement-window-close/:settlementWindowId', () => {
             .put(`/settlement-window-close/${mockData.settleSettlementWindow.request[2].settlementWindowId}`)
             .send(mockData.settleSettlementWindow.request[2].body);
         expect(response.status).toEqual(502);
-        const expectedWindowList = mockData.settlementWindowList;
-        expect(response.body).toEqual(expectedWindowList);
+        // const expectedWindowList = mockData.settlementWindowList;
+        // expect(response.body).toEqual(expectedWindowList);
+        expect(setTimeout).toHaveBeenCalledTimes(1);
+        expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 3000);
     });
 
     test('should return status code 502 if fails to close the window', async () => {
@@ -46,7 +52,9 @@ describe('PUT /settlement-window-close/:settlementWindowId', () => {
             .put(`/settlement-window-close/${mockData.settleSettlementWindow.request[2].settlementWindowId}`)
             .send(mockData.settleSettlementWindow.request[2].body);
         expect(response.status).toEqual(502);
-        const expectedWindowList = mockData.settlementWindowList;
-        expect(response.body).toEqual(expectedWindowList);
+        // const expectedWindowList = mockData.settlementWindowList;
+        // expect(response.body).toEqual(expectedWindowList);
+        expect(setTimeout).toHaveBeenCalledTimes(1);
+        expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 3000);
     });
 });

--- a/src/test/handlers/settlement-window-close.test.js
+++ b/src/test/handlers/settlement-window-close.test.js
@@ -32,20 +32,20 @@ describe('PUT /settlement-window-close/:settlementWindowId', () => {
         expect(response.body).toEqual(expectedWindowList);
     });
 
-    test('should return status code 500 if fails to close the window because the settlement endpoint responds non 202 status', async () => {
+    test('should return status code 502 if fails to close the window because the settlement endpoint responds non 202 status', async () => {
         const response = await request(server)
             .put(`/settlement-window-close/${mockData.settleSettlementWindow.request[2].settlementWindowId}`)
             .send(mockData.settleSettlementWindow.request[2].body);
-        expect(response.status).toEqual(500);
+        expect(response.status).toEqual(502);
         const expectedWindowList = mockData.settlementWindowList;
         expect(response.body).toEqual(expectedWindowList);
     });
 
-    test('should return status code 500 if fails to close the window', async () => {
+    test('should return status code 502 if fails to close the window', async () => {
         const response = await request(server)
             .put(`/settlement-window-close/${mockData.settleSettlementWindow.request[2].settlementWindowId}`)
             .send(mockData.settleSettlementWindow.request[2].body);
-        expect(response.status).toEqual(500);
+        expect(response.status).toEqual(502);
         const expectedWindowList = mockData.settlementWindowList;
         expect(response.body).toEqual(expectedWindowList);
     });

--- a/src/test/handlers/settlement-window-close.test.js
+++ b/src/test/handlers/settlement-window-close.test.js
@@ -4,8 +4,12 @@ const mockData = require('./mock-data');
 const support = require('./_support');
 
 axios.post = jest.fn().mockImplementationOnce(() => Promise.resolve({
-    staus: 200, statusText: 'OK', ok: true,
-})).mockImplementationOnce(() => Promise.reject(new Error('Error')));
+    status: 202, statusText: 'OK', ok: true,
+}))
+    .mockImplementationOnce(() => Promise.resolve({
+        status: 403, statusText: 'FORBIDDEN', ok: false,
+    }))
+    .mockImplementationOnce(() => Promise.reject(new Error('Error')));
 
 let server;
 let db;
@@ -24,6 +28,15 @@ describe('PUT /settlement-window-close/:settlementWindowId', () => {
         const response = await request(server)
             .put(`/settlement-window-close/${mockData.settleSettlementWindow.request[2].settlementWindowId}`);
         expect(response.status).toEqual(200);
+        const expectedWindowList = mockData.settlementWindowList;
+        expect(response.body).toEqual(expectedWindowList);
+    });
+
+    test('should return status code 500 if fails to close the window because the settlement endpoint responds non 202 status', async () => {
+        const response = await request(server)
+            .put(`/settlement-window-close/${mockData.settleSettlementWindow.request[2].settlementWindowId}`)
+            .send(mockData.settleSettlementWindow.request[2].body);
+        expect(response.status).toEqual(500);
         const expectedWindowList = mockData.settlementWindowList;
         expect(response.body).toEqual(expectedWindowList);
     });

--- a/src/test/handlers/settlement-window-close.test.js
+++ b/src/test/handlers/settlement-window-close.test.js
@@ -13,10 +13,9 @@ axios.post = jest.fn().mockImplementationOnce(() => Promise.resolve({
 
 let server;
 let db;
-jest.useFakeTimers();
 
 beforeEach(async () => {
-    jest.useFakeTimers();
+    jest.setTimeout(7000);
     db = support.createDb();
     server = support.createServer(db);
 });
@@ -30,10 +29,8 @@ describe('PUT /settlement-window-close/:settlementWindowId', () => {
         const response = await request(server)
             .put(`/settlement-window-close/${mockData.settleSettlementWindow.request[2].settlementWindowId}`);
         expect(response.status).toEqual(200);
-        // const expectedWindowList = mockData.settlementWindowList;
-        // expect(response.body).toEqual(expectedWindowList);
-        expect(setTimeout).toHaveBeenCalledTimes(1);
-        expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 3000);
+        const expectedWindowList = mockData.settlementWindowList;
+        expect(response.body).toEqual(expectedWindowList);
     });
 
     test('should return status code 502 if fails to close the window because the settlement endpoint responds non 202 status', async () => {
@@ -41,10 +38,8 @@ describe('PUT /settlement-window-close/:settlementWindowId', () => {
             .put(`/settlement-window-close/${mockData.settleSettlementWindow.request[2].settlementWindowId}`)
             .send(mockData.settleSettlementWindow.request[2].body);
         expect(response.status).toEqual(502);
-        // const expectedWindowList = mockData.settlementWindowList;
-        // expect(response.body).toEqual(expectedWindowList);
-        expect(setTimeout).toHaveBeenCalledTimes(1);
-        expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 3000);
+        const expectedWindowList = mockData.settlementWindowList;
+        expect(response.body).toEqual(expectedWindowList);
     });
 
     test('should return status code 502 if fails to close the window', async () => {
@@ -52,9 +47,7 @@ describe('PUT /settlement-window-close/:settlementWindowId', () => {
             .put(`/settlement-window-close/${mockData.settleSettlementWindow.request[2].settlementWindowId}`)
             .send(mockData.settleSettlementWindow.request[2].body);
         expect(response.status).toEqual(502);
-        // const expectedWindowList = mockData.settlementWindowList;
-        // expect(response.body).toEqual(expectedWindowList);
-        expect(setTimeout).toHaveBeenCalledTimes(1);
-        expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 3000);
+        const expectedWindowList = mockData.settlementWindowList;
+        expect(response.body).toEqual(expectedWindowList);
     });
 });


### PR DESCRIPTION
Summary: 
MOWDEV-3985 
1. Use TMF to close settlement windows
2. updated the unit tests 