### PR TITLE
Make insecure cookie insecure

### DIFF
--- a/src/handlers/login.js
+++ b/src/handlers/login.js
@@ -9,7 +9,7 @@ const selfSignedAgent = new https.Agent({ rejectUnauthorized: false });
 // TODO: set the Max-Age directive corresponding to the token expiry time.
 const cookieDirectives = (token, insecure) => insecure
     ? `token=${token};`
-    : `token=${token}; HttpOnly; SameSite=strict; Secure'`
+    : `token=${token}; HttpOnly; SameSite=strict; Secure`
 
 const handler = (router, routesContext) => {
     router.post('/login', async (ctx, next) => {

--- a/src/handlers/login.js
+++ b/src/handlers/login.js
@@ -7,9 +7,9 @@ const qs = require('querystring');
 const selfSignedAgent = new https.Agent({ rejectUnauthorized: false });
 
 // TODO: set the Max-Age directive corresponding to the token expiry time.
-const cookieDirectives = (token, insecure) => insecure
-    ? `token=${token};`
-    : `token=${token}; HttpOnly; SameSite=strict; Secure`
+const cookieDirectives = (token, insecure) => (
+    insecure ? `token=${token};` : `token=${token}; HttpOnly; SameSite=strict; Secure`
+);
 
 const handler = (router, routesContext) => {
     router.post('/login', async (ctx, next) => {
@@ -19,7 +19,7 @@ const handler = (router, routesContext) => {
                 expiresIn: '3600',
             };
             ctx.response.set({
-                'Set-Cookie': cookieDirectives('bypassed', routesContext.config.insecureCookie)
+                'Set-Cookie': cookieDirectives('bypassed', routesContext.config.insecureCookie),
             });
             ctx.response.status = 200;
             await next();
@@ -54,7 +54,7 @@ const handler = (router, routesContext) => {
             expiresIn: oauth2Token.expires_in,
         };
         ctx.response.set({
-            'Set-Cookie': cookieDirectives(oauth2Token.access_token, routesContext.config.insecureCookie)
+            'Set-Cookie': cookieDirectives(oauth2Token.access_token, routesContext.config.insecureCookie),
         });
         ctx.response.status = 200;
 

--- a/src/server.js
+++ b/src/server.js
@@ -106,19 +106,19 @@ const createServer = (config, db, log, Database) => {
     // TODO: authorise before handling CORS?
     app.use(async (ctx, next) => {
         if (ctx.request.path.split('/').pop() === 'login' && ctx.request.method.toLowerCase() === 'post') {
-            log('bypassing validation on login request');
+            log('login request received - user will authenticate with login credentials - token validation not performed');
             await next();
             return;
         }
         if (config.auth.bypass) {
-            log('request validation bypassed');
+            log('request token validation bypassed as per config');
             await next();
             return;
         }
 
         const token = ctx.request.get('Cookie').split('=').splice(1).join('');
 
-        log('validating request, token:', token);
+        log('validating request token:', token);
         const opts = {
             method: 'POST',
             headers: {

--- a/src/test/handlers/login.test.js
+++ b/src/test/handlers/login.test.js
@@ -1,0 +1,35 @@
+// Disable camelcase for use of access_token, as propagated from wso2
+/* eslint-disable camelcase */
+const request = require('supertest');
+const fetch = require('node-fetch');
+
+const support = require('./_support');
+const globalConfig = require('../../config/config');
+
+const { Response } = jest.requireActual('node-fetch');
+
+jest.mock('node-fetch');
+
+describe('POST /login', () => {
+    test('should respond with insecure directives when cookie is set to insecure', async () => {
+        const config = { ...globalConfig, insecureCookie: true, auth: { bypass: false } };
+        const server = support.createServer({ db: support.createDb(), config });
+        const access_token = 'whatever';
+        fetch.mockReturnValue(Promise.resolve(new Response(JSON.stringify({ access_token }))));
+        const response = await request(server).post('/login');
+        expect(response.status).toEqual(200);
+        expect(response.headers['set-cookie']).toEqual([`token=${access_token};`]);
+    });
+
+    test('should respond with secure directives when cookie is not set to insecure', async () => {
+        const config = { ...globalConfig, insecureCookie: false, auth: { bypass: false } };
+        const server = support.createServer({ db: support.createDb(), config });
+        const access_token = 'whatever';
+        fetch.mockReturnValue(Promise.resolve(new Response(JSON.stringify({ access_token }))));
+        const response = await request(server).post('/login');
+        expect(response.status).toEqual(200);
+        expect(response.headers['set-cookie']).toEqual([
+            `token=${access_token}; HttpOnly; SameSite=strict; Secure`,
+        ]);
+    });
+});


### PR DESCRIPTION
The meat of this change is to remove `HttpOnly` and `Samesite=strict` from the cookie directives when `INSECURE_COOKIE=true` in the environment. This means a cookie will be set in the session and used by the browser regardless of origin. This facilitates easier testing during development.