### PR TITLE
feat!: pass through settlement API response info

### DIFF
--- a/src/handlers/settlement-window-close.js
+++ b/src/handlers/settlement-window-close.js
@@ -7,33 +7,34 @@ const handler = (router, routesContext) => {
     router.put('/settlement-window-close/:settlementWindowId', async (ctx, next) => {
         const { startDate: fromDateTime, endDate: toDateTime } = ctx.request.body;
 
-        try {
-            const resp = await axios.post(
-                `${routesContext.config.centralSettlementsEndpoint}/settlementWindows/${ctx.params.settlementWindowId}`,
-                {
-                    state: 'CLOSED',
-                    reason: 'Finance portal user request',
-                },
-            );
-            if (resp.status === 200) {
-                ctx.response.status = 200;
-            } else {
-                ctx.response.status = 502;
-            }
-        } catch (err) {
-            ctx.response.status = 502;
-        } finally {
-            // this delay is introduced in order to give the external settlement API enough time
+        const resp = await axios.post(
+            `${routesContext.config.centralSettlementsEndpoint}/settlementWindows/${ctx.params.settlementWindowId}`,
+            {
+                state: 'CLOSED',
+                reason: 'Finance portal user request',
+            },
+            {
+                validateStatus: null,
+            },
+        );
+
+        ctx.response.status = resp.status;
+
+        if (resp.status === 200) {
+            // this delay is introduced in order to give the central settlement API enough time
             // to close the window
-            // TODO revise the implementation of the external settlement API so it sends back an
-            //  acknowledgment somehow
+            // TODO revise the implementation of the central settlement API so it sends back an
+            // acknowledgment somehow
             await sleep(3000);
             ctx.response.body = await handlerHelpers.getSettlementWindows(
                 routesContext,
                 fromDateTime,
                 toDateTime,
             );
+        } else {
+            ctx.response.body = resp.data;
         }
+
         await next();
     });
 };

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mojaloop/finance-portal-backend-service",
-  "version": "12.0.0",
+  "version": "13.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mojaloop/finance-portal-backend-service",
-      "version": "12.0.0",
+      "version": "13.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@mojaloop/finance-portal-lib": "^0.1.1",

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/finance-portal-backend-service",
-  "version": "12.0.0",
+  "version": "13.0.0",
   "description": "The backend service to support the finance portal web ui. Essentially a thin wrapper around SQL queries.",
   "license": "Apache-2.0",
   "contributors": [

--- a/src/test/handlers/settlement-window-close.test.js
+++ b/src/test/handlers/settlement-window-close.test.js
@@ -28,25 +28,23 @@ describe('PUT /settlement-window-close/:settlementWindowId', () => {
         expect(response.body).toEqual(expectedWindowList);
     });
 
-    test('should return status code 502 if fails to close the window because the settlement endpoint responds non 202 status', async () => {
+    test('should return status code 502 and error information if fails to close the window because the settlement endpoint responds non 202 status', async () => {
+        const data = { errorInformation: 'error information' };
         axios.post = jest.fn().mockImplementationOnce(() => Promise.resolve({
-            status: 403, statusText: 'FORBIDDEN', ok: false,
+            status: 403, statusText: 'FORBIDDEN', ok: false, data,
         }));
         const response = await request(server)
             .put(`/settlement-window-close/${mockData.settleSettlementWindow.request[2].settlementWindowId}`)
             .send(mockData.settleSettlementWindow.request[2].body);
-        expect(response.status).toEqual(502);
-        const expectedWindowList = mockData.settlementWindowList;
-        expect(response.body).toEqual(expectedWindowList);
+        expect(response.status).toEqual(403);
+        expect(response.body).toEqual(data);
     });
 
-    test('should return status code 502 if fails to close the window', async () => {
+    test('should return status code 500 if fails to close the window', async () => {
         axios.post = jest.fn().mockImplementationOnce(() => Promise.reject(new Error('Error')));
         const response = await request(server)
             .put(`/settlement-window-close/${mockData.settleSettlementWindow.request[2].settlementWindowId}`)
             .send(mockData.settleSettlementWindow.request[2].body);
-        expect(response.status).toEqual(502);
-        const expectedWindowList = mockData.settlementWindowList;
-        expect(response.body).toEqual(expectedWindowList);
+        expect(response.status).toEqual(500);
     });
 });


### PR DESCRIPTION
Pass through response status and error information from central settlement for settlement window close