### PR TITLE
fix: actually log the userinfo object returned by the IAM

### DIFF
--- a/src/lib/permissions.js
+++ b/src/lib/permissions.js
@@ -14,7 +14,7 @@ const permit = async (userInfoURL, token, requestMethod, requestPath, log) => {
         agent: selfSignedAgent,
     };
     const userinfo = await fetch(userInfoURL, opts).then((res) => res.json());
-    log.info('Got userinfo:', userinfo);
+    log.info(`Got userinfo: ${userinfo}`);
 
     const usergroups = userinfo.groups ? userinfo.groups.split(',') : [];
     if (requestPath.includes('netdebitcap') && requestMethod === 'POST') {


### PR DESCRIPTION
Userinfo object is not currently logged due to a misunderstanding of the logger api. This fixes it.

Example of current log output showing the issue:

`{"level":30,"time":1629199407789,"pi[redacted]XFiucU"}},"msg":"Got userinfo:"}`